### PR TITLE
Allow to manage sauce tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Executor for [Magellan](https://github.com/TestArmada/magellan) to run [nightwat
 ## What does this executor do
  1. It talks [Muffin]() so that the desiredCapabilities shrinks down to a string, which makes your browser selection an easy work
  2. It runs nightwatch test by forking it as magellan child process
+ 3. It launches sauce tunnel and manages its life cycle for you during test. Check this [page](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+and+Real+Device+Testing) for more details.
 
 ## How To Use
 Please follow the steps
@@ -24,16 +25,20 @@ Please follow the steps
  ]
  ```
  3. set env variables
- ```
+ ```bash
  export TESTOBJECT_USERNAME=${USERNAME}
  export TESTOBJECT_API_KEY=${ACCESS_KEY}
  ```
 
+If you want to use this executor to launch sauce tunnel for you, set this env variable.
+```bash
+export TESTOBJECT_PASSWORD=${PASSWORD}
+``` 
+
 Optional env variable. If set, all traffic to TestObject, including TestObject api and selenium calls, will be going through it.
-```
+```bash
 export TESTOBJECT_OUTBOUND_PROXY=http://${your.proxy}:${your.port}
 ```
-
 
  4. `./node_modules/.bin/magellan --help` to see if you can see the following content printed out
  ```
@@ -41,12 +46,28 @@ export TESTOBJECT_OUTBOUND_PROXY=http://${your.proxy}:${your.port}
    --to_device=devicename               String represents one device which TestObject supports
    --to_devices=d1,d2,..                String represents multiple devices which TestObject supports
    --to_list_devices                    List the available devices TestObject supports.
+   --to_create_tunnel                   Create and use sauce tunnel for testing
+   --to_tunnel_id                       Existing tunnel identifier for testing
    --to_app_id=1                        APP id of the uploaded app to TestObject
    --to_platform_name=iOS               String represents the mobile platform
    --to_platform_version=10.2           String represents the mobile platform version
  ```
 
 Congratulations, you're all set. 
+
+## Run your test with sauce tunnel
+TestObject recently launched the beta program to run real device test with sauce tunnel. Find more info [here](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy+and+Real+Device+Testing). You can tell this executor if you want it to manage sauce tunnel for you during test, or if you want to use an existing sauce tunnel.
+
+1. launch sauce tunnel automatically
+
+Simply set `TESTOBJECT_PASSWORD` env variable and add `--to_create_tunnel` to your command line. This executor will create a tunnel for you per magellan run, and automatically close it eventually.
+
+2. use an existing sauce tunnel
+
+Add `--to_tunnel_id ${TUNNEL_ID}` to your command line. This executor will add `${TUNNEL_ID}` to desiredCapabilities.
+
+Please note: `--to_create_tunnel` and `--to_tunnel_id` cannot co-exist. Once executor founds them both from command line, `--to_create_tunnel` will be in use. 
+
 
 ## Run your test in parallel
 TestObject takes both generic device desiredCapability with device and platform information and specific device id. A specific device id is a string that TestObject uses as an unique identifier to represent a particular device. There are two ways to get device id

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/TestArmada/magellan-testobject-executor.svg?branch=master)](https://travis-ci.org/TestArmada/magellan-testobject-executor)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/TestArmada/magellan-testobject-executor/branch/master/graph/badge.svg)](https://codecov.io/gh/TestArmada/magellan-testobject-executor)
+[![Downloads](http://img.shields.io/npm/dm/testarmada-magellan-testobject-executor?style=flat)](https://npmjs.org/package/testarmada-magellan-testobject-executor)
 
 Executor for [Magellan](https://github.com/TestArmada/magellan) to run [nightwatchjs](http://nightwatchjs.org/) tests in [TestObject](https://testobject.com/) environment.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const executor = require("./lib/executor").default;
+const executor = require("./lib/executor");
 const configuration = require("./lib/configuration").default;
 const profile = require("./lib/profile").default;
 const help = require("./lib/help").default;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-testobject-executor",
-  "version": "1.3.1",
+  "version": "1.4.0-beta1",
   "description": "magellan executor for testobject",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
     "cli-table": "^0.3.1",
     "lodash": "^4.17.4",
     "request": "^2.81.0",
+    "sauce-connect-launcher": "^1.2.2",
     "testarmada-logger": "^1.1.1",
     "yargs": "^6.6.0"
   },
@@ -40,7 +41,8 @@
   "keywords": [
     "magellan",
     "executor",
-    "testobject"
+    "testobject",
+    "saucelabs"
   ],
   "author": "Lei Zhu <thunderzhulei@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-magellan-testobject-executor",
-  "version": "1.4.0-beta1",
+  "version": "1.4.0",
   "description": "magellan executor for testobject",
   "main": "index.js",
   "scripts": {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -59,11 +59,11 @@ export default {
       // required
       settings.config.tunnel.username = settings.config.accessUser;
 
-      settings.config.tunnel.password = env.TESTOBJECT_PASSWORD;
+      settings.config.tunnel.accessKey = env.TESTOBJECT_PASSWORD;
       // optional
-      if (runArgv.to_password && !settings.config.tunnel.password) {
+      if (runArgv.to_password && !settings.config.tunnel.accessKey) {
         // only accept argument from command line if env variable isn't set
-        settings.config.tunnel.password = runArgv.to_password;
+        settings.config.tunnel.accessKey = runArgv.to_password;
       }
 
       settings.config.tunnel.tunnelIdentifier = guid();
@@ -128,7 +128,7 @@ export default {
 
       // validate tunnel configs
       if (runArgv.to_create_tunnel) {
-        if (!settings.config.tunnel.password) {
+        if (!settings.config.tunnel.accessKey) {
           logger.err(`TestObject requires TESTOBJECT_PASSWORD to be set. Check if the`
             + ` environment variable TESTOBJECT_PASSWORD is defined.`);
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -3,6 +3,12 @@ import _ from "lodash";
 import logger from "testarmada-logger";
 import settings from "./settings";
 
+const TESTOBJECT_REST_URL = "https://us1.api.testobject.com/sc/rest/v1";
+const RAND_MAX = 9999999999999999;
+const STRNUM_BASE = 16;
+
+const guid = () => Math.round(Math.random() * RAND_MAX).toString(STRNUM_BASE);
+
 export default {
   getConfig: () => {
     logger.prefix = "TestObject Executor";
@@ -48,6 +54,27 @@ export default {
       settings.config.testobjectOutboundProxy = env.TESTOBJECT_OUTBOUND_PROXY;
     }
 
+    if (runArgv.to_create_tunnel) {
+      // if to_create_tunnel is in use
+      // required
+      settings.config.tunnel.username = settings.config.accessUser;
+
+      settings.config.tunnel.password = env.TESTOBJECT_PASSWORD;
+      // optional
+      if (runArgv.to_password && !settings.config.tunnel.password) {
+        // only accept argument from command line if env variable isn't set
+        settings.config.tunnel.password = runArgv.to_password;
+      }
+
+      settings.config.tunnel.tunnelIdentifier = guid();
+      settings.config.tunnel.restUrl = TESTOBJECT_REST_URL;
+      settings.config.useTunnels = true;
+    } else if (runArgv.to_tunnel_id) {
+      // if tunnel id is passed in
+      settings.config.tunnel.tunnelIdentifier = runArgv.to_tunnel_id;
+      settings.config.tunnel.restUrl = TESTOBJECT_REST_URL;
+    }
+
     settings.config.appID = runArgv.to_app_id;
 
     const parameterWarnings = {
@@ -72,11 +99,11 @@ export default {
       _.forEach(parameterWarnings, (v, k) => {
         if (!settings.config[k]) {
           if (v.required) {
-            logger.err(`Error! TestObject requires ${k} to be set. Check if the`
+            logger.err(`TestObject requires ${k} to be set. Check if the`
               + ` environment variable $${v.envKey} is defined.`);
             valid = false;
           } else {
-            logger.warn(`Warning! No ${k} is set. This is set via the`
+            logger.warn(`No ${k} is set. This is set via the`
               + ` environment variable $${v.envKey} . This isn't required, but can cause `
               + "problems with TestObject if not set");
           }
@@ -97,6 +124,21 @@ export default {
         (runArgv.to_platform_name || runArgv.to_platform_version)) {
         throw new Error("--to_devices and --to_platform_name or --to_platform_name "
           + "cannot co-exist in the arguments");
+      }
+
+      // validate tunnel configs
+      if (runArgv.to_create_tunnel) {
+        if (!settings.config.tunnel.password) {
+          logger.err(`TestObject requires TESTOBJECT_PASSWORD to be set. Check if the`
+            + ` environment variable TESTOBJECT_PASSWORD is defined.`);
+
+          throw new Error("Missing configuration for TestObject connection.");
+        }
+
+        if (runArgv.to_tunnel_id) {
+          logger.warn("--to_create_tunnel and --to_tunnel_id shouldn't be used together." +
+            " TestObject excutor will ignore --to_tunnel_id in this case.");
+        }
       }
 
       logger.debug("TestObject configuration: ");

--- a/src/help.js
+++ b/src/help.js
@@ -28,6 +28,22 @@ export default {
     "example": "mikebrown",
     "description": "Your TestObject username"
   },
+  "to_password": {
+    "visible": false,
+    "type": "string",
+    "example": "sd9f81l",
+    "description": "Your TestObject password, for creating tunnel"
+  },
+  "to_create_tunnel": {
+    "visible": true,
+    "type": "boolean",
+    "description": "Create and use sauce tunnel for testing"
+  },
+  "to_tunnel_id": {
+    "visible": true,
+    "type": "string",
+    "description": "Existing tunnel identifier for testing"
+  },
   "to_app_id": {
     "visible": true,
     "type": "string",

--- a/src/profile.js
+++ b/src/profile.js
@@ -23,6 +23,11 @@ export default {
       config.proxy = settings.config.testobjectOutboundProxy;
     }
 
+    if (settings.config.tunnel.tunnelIdentifier) {
+      // we're told to use tunnel
+      config.desiredCapabilities.tunnelIdentifier = settings.config.tunnel.tunnelIdentifier;
+    }
+
     logger.debug(`executor config: ${JSON.stringify(config)}`);
     return config;
   },

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,17 +1,35 @@
 import { argv } from "yargs";
+import path from "path";
 
 const debug = argv.debug;
 const API_DELAY = 20000;
+const tempDir = path.resolve(argv.temp_dir || "./temp");
 
+/*eslint-disable no-magic-numbers*/
 const config = {
   accessUser: null,
   accessAPI: null,
   appID: null,
-  testobjectOutboundProxy: null
+  testobjectOutboundProxy: null,
+
+  useTunnels: false,
+
+  tunnel: {
+    username: null,
+    password: null,
+    restUrl: null,
+
+    // optional
+    tunnelIdentifier: null,
+    connectVersion: null
+  }
 };
 
 export default {
   debug,
+  tempDir,
+  MAX_CONNECT_RETRIES: process.env.SAUCE_CONNECT_NUM_RETRIES || 10,
   TESTOBJECT_API_DELAY: process.env.TESTOBJECT_API_DELAY || API_DELAY,
+  BASE_SELENIUM_PORT_OFFSET: 56000,
   config
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -16,7 +16,7 @@ const config = {
 
   tunnel: {
     username: null,
-    password: null,
+    accessKey: null,
     restUrl: null,
 
     // optional

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -64,7 +64,7 @@ export default class Tunnel {
           logfile: logFilePath,
           port: settings.BASE_SELENIUM_PORT_OFFSET,
           // for sauce tunnel beta program
-          noSslBumpDomains: 'all'
+          noSslBumpDomains: "all"
         });
 
         logger.debug(`calling sauceConnectLauncher() w/ ${JSON.stringify(sauceOptions)}`);

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -1,0 +1,127 @@
+import sauceConnectLauncher from "sauce-connect-launcher";
+import logger from "testarmada-logger";
+import path from "path";
+import _ from "lodash";
+import settings from "./settings";
+
+export default class Tunnel {
+  constructor(options, sauceConnectLauncherMock = null) {
+    this.options = _.assign({}, options);
+    this.sauceConnectLauncher = sauceConnectLauncher;
+
+    if (sauceConnectLauncherMock) {
+      this.sauceConnectLauncher = sauceConnectLauncherMock;
+    }
+  }
+
+  initialize() {
+    logger.prefix = "TestObject Executor";
+
+    return new Promise((resolve, reject) => {
+      if (!this.options.tunnel.username) {
+        return reject("Sauce tunnel support is missing configuration: Sauce username.");
+      }
+
+      if (!this.options.tunnel.password) {
+        return reject("Sauce tunnel support is missing configuration: Sauce password.");
+      }
+
+      const options = _.assign({}, this.options.tunnel, { logger: logger.debug });
+      /*eslint-disable no-console */
+      return this.sauceConnectLauncher.download(options, (err) => {
+        if (err) {
+          logger.err("Failed to download sauce connect binary:");
+          logger.err(err);
+          logger.err("sauce-connect-launcher will attempt to re-download " +
+            "next time it is run.");
+          return reject(err);
+        } else {
+          return resolve();
+        }
+      });
+    });
+
+  }
+
+  open() {
+    logger.prefix = "TestObject Executor";
+
+    this.tunnelInfo = null;
+    let connectFailures = 0;
+
+    logger.log(`Opening sauce tunnel [${this.options.tunnel.tunnelIdentifier}]`
+      + ` for user ${this.options.tunnel.username}`);
+
+    const connect = (/*runDiagnostics*/) => {
+      return new Promise((resolve, reject) => {
+        const logFilePath = `${path.resolve(settings.tempDir)}/build-${
+          settings.buildId}_sauceconnect_${this.options.tunnel.tunnelIdentifier}.log`;
+
+        const sauceOptions = _.assign({}, this.options.tunnel, {
+          readyFileId: this.options.tunnel.tunnelIdentifier,
+          verbose: settings.debug,
+          verboseDebugging: settings.debug,
+          logfile: logFilePath,
+          port: settings.BASE_SELENIUM_PORT_OFFSET
+        });
+
+        logger.debug(`calling sauceConnectLauncher() w/ ${JSON.stringify(sauceOptions)}`);
+
+        this.sauceConnectLauncher(sauceOptions, (err, sauceConnectProcess) => {
+          if (err) {
+            logger.debug("Error from sauceConnectLauncher():");
+            logger.debug(err.message);
+
+            if (err.message && err.message.indexOf("Could not start Sauce Connect") > -1) {
+              return reject(err.message);
+            } else if (settings.BAILED) {
+              connectFailures++;
+              // If some other parallel tunnel construction attempt has tripped the BAILED flag
+              // Stop retrying and report back a failure.
+              return reject(new Error("Bailed due to maximum number of tunnel retries."));
+            } else {
+              connectFailures++;
+
+              if (connectFailures >= settings.MAX_CONNECT_RETRIES) {
+                // We've met or exceeded the number of max retries, stop trying to connect.
+                // Make sure other attempts don't try to re-state this error.
+                settings.BAILED = true;
+                return reject(new Error(`Failed to create a secure sauce tunnel after ${
+                  connectFailures} attempts.`));
+              } else {
+                // Otherwise, keep retrying, and hope this is merely a blip and not an outage.
+                logger.err(`>>> Sauce Tunnel Connection Failed!  Retrying ${
+                  connectFailures} of ${settings.MAX_CONNECT_RETRIES} attempts...`);
+
+                return connect()
+                  .then(resolve)
+                  .catch(reject);
+              }
+            }
+          } else {
+            this.tunnelInfo = { process: sauceConnectProcess };
+            return resolve();
+          }
+        });
+      });
+    };
+
+    return connect();
+  }
+
+  close() {
+    logger.prefix = "TestObject Executor";
+
+    return new Promise((resolve) => {
+      if (this.tunnelInfo) {
+        logger.log(`Closing sauce tunnel [${this.options.tunnel.tunnelIdentifier}]`);
+        this.tunnelInfo.process.close(() => {
+          resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+
+  }
+}

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -22,7 +22,7 @@ export default class Tunnel {
         return reject("Sauce tunnel support is missing configuration: Sauce username.");
       }
 
-      if (!this.options.tunnel.password) {
+      if (!this.options.tunnel.accessKey) {
         return reject("Sauce tunnel support is missing configuration: Sauce password.");
       }
 
@@ -62,7 +62,9 @@ export default class Tunnel {
           verbose: settings.debug,
           verboseDebugging: settings.debug,
           logfile: logFilePath,
-          port: settings.BASE_SELENIUM_PORT_OFFSET
+          port: settings.BASE_SELENIUM_PORT_OFFSET,
+          // for sauce tunnel beta program
+          noSslBumpDomains: 'all'
         });
 
         logger.debug(`calling sauceConnectLauncher() w/ ${JSON.stringify(sauceOptions)}`);

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -137,6 +137,104 @@ describe("Configuration", () => {
             + "cannot co-exist in the arguments");
         }
       });
+
+
+      it("--to_tunnel_id is set", () => {
+        let argvMock = {
+          to_devices: "Samsung_Galaxy_S7_real",
+          to_tunnel_id: "FAKE_TUNNEL_ID"
+        };
+        let envMock = {
+          TESTOBJECT_USERNAME: "FAKE_USERNAME",
+          TESTOBJECT_API_KEY: "FAKE_ACCESSKEY"
+        };
+
+        const config = configuration.validateConfig({}, argvMock, envMock);
+
+        expect(config.accessAPI).to.equal("FAKE_ACCESSKEY");
+        expect(config.accessUser).to.equal("FAKE_USERNAME");
+        expect(config.useTunnels).to.equal(false);
+        expect(config.tunnel.tunnelIdentifier).to.equal("FAKE_TUNNEL_ID");
+        expect(config.tunnel.restUrl).to.not.equal(null);
+      });
+
+      it("--to_create_tunnel is set", () => {
+        let argvMock = {
+          to_devices: "Samsung_Galaxy_S7_real",
+          to_create_tunnel: true
+        };
+        let envMock = {
+          TESTOBJECT_USERNAME: "FAKE_USERNAME",
+          TESTOBJECT_API_KEY: "FAKE_ACCESSKEY",
+          TESTOBJECT_PASSWORD: "FAKE_PASSWORD"
+        };
+
+        const config = configuration.validateConfig({}, argvMock, envMock);
+
+        expect(config.accessAPI).to.equal("FAKE_ACCESSKEY");
+        expect(config.accessUser).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.username).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.password).to.equal("FAKE_PASSWORD");
+        expect(config.useTunnels).to.equal(true);
+        expect(config.tunnel.tunnelIdentifier).to.not.equal(null);
+        expect(config.tunnel.restUrl).to.not.equal(null);
+      });
+
+
+      it("--to_create_tunnel is set without TESTOBJECT_PASSWORD", () => {
+        let argvMock = {
+          to_devices: "Samsung_Galaxy_S7_real",
+          to_create_tunnel: true,
+          to_password: "FAKE_PASSWORD"
+        };
+        let envMock = {
+          TESTOBJECT_USERNAME: "FAKE_USERNAME",
+          TESTOBJECT_API_KEY: "FAKE_ACCESSKEY"
+        };
+
+        const config = configuration.validateConfig({}, argvMock, envMock);
+
+        expect(config.accessAPI).to.equal("FAKE_ACCESSKEY");
+        expect(config.accessUser).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.username).to.equal("FAKE_USERNAME");
+        expect(config.tunnel.password).to.equal("FAKE_PASSWORD");
+        expect(config.useTunnels).to.equal(true);
+        expect(config.tunnel.tunnelIdentifier).to.not.equal(null);
+        expect(config.tunnel.restUrl).to.not.equal(null);
+      });
+
+      it("co-existence of --to_tunnel_id and --to_create_tunnel", () => {
+        let argvMock = {
+          to_devices: "Samsung_Galaxy_S7_real",
+          to_tunnel_id: "FAKE_TUNNEL_ID",
+          to_create_tunnel: true
+        };
+        let envMock = {
+          TESTOBJECT_USERNAME: "FAKE_USERNAME",
+          TESTOBJECT_API_KEY: "FAKE_ACCESSKEY",
+          TESTOBJECT_PASSWORD: "FAKE_PASSWORD"
+        };
+
+        const config = configuration.validateConfig({}, argvMock, envMock);
+      });
+
+      it("--to_create_tunnel without TESTOBJECT_PASSWORD", () => {
+        let argvMock = {
+          to_devices: "Samsung_Galaxy_S7_real",
+          to_create_tunnel: true
+        };
+        let envMock = {
+          TESTOBJECT_USERNAME: "FAKE_USERNAME",
+          TESTOBJECT_API_KEY: "FAKE_ACCESSKEY"
+        };
+
+        try {
+          configuration.validateConfig({}, argvMock, envMock);
+          assert(false, "TestObject shouldn't pass verification.");
+        } catch (e) {
+          expect(e.message).to.equal("Missing configuration for TestObject connection.");
+        }
+      });
     });
   });
 });

--- a/test/src/configuration.test.js
+++ b/test/src/configuration.test.js
@@ -174,7 +174,7 @@ describe("Configuration", () => {
         expect(config.accessAPI).to.equal("FAKE_ACCESSKEY");
         expect(config.accessUser).to.equal("FAKE_USERNAME");
         expect(config.tunnel.username).to.equal("FAKE_USERNAME");
-        expect(config.tunnel.password).to.equal("FAKE_PASSWORD");
+        expect(config.tunnel.accessKey).to.equal("FAKE_PASSWORD");
         expect(config.useTunnels).to.equal(true);
         expect(config.tunnel.tunnelIdentifier).to.not.equal(null);
         expect(config.tunnel.restUrl).to.not.equal(null);
@@ -197,7 +197,7 @@ describe("Configuration", () => {
         expect(config.accessAPI).to.equal("FAKE_ACCESSKEY");
         expect(config.accessUser).to.equal("FAKE_USERNAME");
         expect(config.tunnel.username).to.equal("FAKE_USERNAME");
-        expect(config.tunnel.password).to.equal("FAKE_PASSWORD");
+        expect(config.tunnel.accessKey).to.equal("FAKE_PASSWORD");
         expect(config.useTunnels).to.equal(true);
         expect(config.tunnel.tunnelIdentifier).to.not.equal(null);
         expect(config.tunnel.restUrl).to.not.equal(null);

--- a/test/src/executor.test.js
+++ b/test/src/executor.test.js
@@ -9,18 +9,127 @@ const expect = chai.expect;
 const assert = chai.assert;
 
 describe("Executor", () => {
-  it("setupRunner", () => {
-    return executor
-      .setupRunner()
-      .then()
-      .catch(err => assert(false, "executor doesn't setup correctly." + err));
+  describe("setupRunner", () => {
+
+    let mocks;
+
+    beforeEach(() => {
+      mocks = {
+        Tunnel: class Tunnel {
+          constructor(config) { }
+          initialize() { return new Promise((resolve) => resolve()) }
+          open() { return new Promise((resolve) => resolve()) }
+        },
+
+        config: {
+          tunnel: {}
+        }
+      };
+    });
+
+    it("without tunnel", () => {
+      mocks.config.useTunnels = false;
+
+      return executor
+        .setupRunner(mocks)
+        .then()
+        .catch(err => assert(false, "executor doesn't setup correctly." + err));
+    });
+
+    it("use existing tunnel", () => {
+      mocks.config = {
+        useTunnels: false,
+        tunnel: {
+          tunnelIdentifier: "FAKE_ID"
+        }
+      };
+
+      return executor
+        .setupRunner(mocks)
+        .then(() => { })
+        .catch(err => assert(false, "executor setupRunner isn't successful for use existing tunnel config"));
+    });
+
+    it("create new tunnel", () => {
+      mocks.config.useTunnels = true;
+
+      return executor
+        .setupRunner(mocks)
+        .then(() => { })
+        .catch(err => assert(false, "executor setupRunner isn't successful for create new tunnel config"));
+    });
+
+    it("create new tunnel failed in initialization", () => {
+      mocks.config.useTunnels = true;
+
+      mocks.Tunnel = class Tunnel {
+        constructor(config) { }
+        initialize() { return new Promise((resolve, reject) => reject("initialization error")) }
+        open() { return new Promise((resolve) => resolve()) }
+      };
+
+      return executor
+        .setupRunner(mocks)
+        .then(() => assert(false, "executor setupRunner isn't successful"))
+        .catch(err => expect(err).to.equal("initialization error"));
+    });
+
+    it("create new tunnel failed in open", () => {
+      mocks.config.useTunnels = true;
+
+      mocks.Tunnel = class Tunnel {
+        constructor(config) { }
+        initialize() { return new Promise((resolve) => resolve()) }
+        open() { return new Promise((resolve, reject) => reject("open error")) }
+      };
+
+      return executor
+        .setupRunner(mocks)
+        .then(() => assert(false, "executor setupRunner isn't successful"))
+        .catch(err => expect(err).to.equal("open error"));
+    });
   });
 
-  it("teardownRunner", () => {
-    return executor
-      .teardownRunner()
-      .then()
-      .catch(err => assert(false, "executor doesn't teardown correctly." + err));
+  describe("teardownRunner", () => {
+    it("no create tunnel", () => {
+      let mocks = {
+        Tunnel: class Tunnel {
+          constructor(config) { }
+          initialize() { return new Promise((resolve) => resolve()) }
+          open() { return new Promise((resolve) => resolve()) }
+        },
+
+        config: { tunnel: {} }
+      };
+
+      return executor
+        .teardownRunner(mocks)
+        .then()
+        .catch(err => assert(false, "executor doesn't teardown correctly." + err));
+    });
+
+    it("use tunnel", () => {
+      let mocks = {
+        Tunnel: class Tunnel {
+          constructor(config) { }
+          initialize() { return new Promise((resolve) => resolve()) }
+          open() { return new Promise((resolve) => resolve()) }
+          close() { return new Promise((resolve) => resolve()) }
+        },
+
+        config: {
+          useTunnels: true,
+          tunnel: {
+            tunnelIdentifier: null
+          }
+        }
+      };
+
+      return executor
+        .setupRunner(mocks)
+        .then(() => executor.teardownRunner(mocks))
+        .catch(err => assert(false, "executor teardownRunner isn't successful for use tunnel config"));
+    });
   });
 
   it("setupTest", (done) => {

--- a/test/src/profile.test.js
+++ b/test/src/profile.test.js
@@ -15,6 +15,7 @@ describe("Profile", function () {
 
   afterEach(() => {
     settings.config.testobjectOutboundProxy = null;
+    settings.config.tunnel.tunnelIdentifier = null;
   });
 
   describe("getProfiles", () => {
@@ -51,7 +52,6 @@ describe("Profile", function () {
       return profile
         .getProfiles({}, argvMock)
         .then((profiles) => {
-          console.log(profiles[0])
           expect(profiles.length).to.equal(2);
           expect(profiles[0].desiredCapabilities.deviceName).to.equal("Samsung_Galaxy_S7_real");
           expect(profiles[0].desiredCapabilities.testobjectApiKey).to.equal(process.env.TESTOBJECT_API_KEY);
@@ -116,16 +116,18 @@ describe("Profile", function () {
 
   describe("getNightwatchConfig", () => {
     settings.config.testobjectOutboundProxy = "FAKE_PROXY";
+    settings.config.tunnel.tunnelIdentifier = "FAKE_TUNNLE_ID";
     
     const config = profile.getNightwatchConfig({
       desiredCapabilities: {
         "deviceName": "Asus_Google_Nexus_7_real",
-        "testobjectApiKey": "FAKE_KEY"
+        "testobjectApiKey": "FAKE_KEY",
       }
     });
 
     expect(config.desiredCapabilities.deviceName).to.equal("Asus_Google_Nexus_7_real");
     expect(config.desiredCapabilities.testobjectApiKey).to.equal("FAKE_KEY");
+    expect(config.desiredCapabilities.tunnelIdentifier).to.equal("FAKE_TUNNLE_ID");
     expect(config.proxy).to.equal("FAKE_PROXY");
   });
 });

--- a/test/src/tunnel.test.js
+++ b/test/src/tunnel.test.js
@@ -1,0 +1,147 @@
+import Tunnel from "../../lib/tunnel";
+import chai from "chai";
+import chaiAsPromise from "chai-as-promised";
+import _ from "lodash";
+
+chai.use(chaiAsPromise);
+
+const expect = chai.expect;
+const assert = chai.assert;
+
+describe("Tunnel", () => {
+  let tunnel;
+
+  let options = {
+    tunnel: {
+      username: "FAKE_USERNAME",
+      password: "FAKE_PASSWORD",
+      tunnelIdentifier: "FAKE_TUNNELID"
+    }
+  };
+
+  let sauceConnectLauncherMock = {
+    download(opts, callback) {
+      callback(null);
+    }
+  };
+
+  beforeEach(() => {
+    tunnel = new Tunnel(options, sauceConnectLauncherMock);
+  });
+
+  it("constructor", () => {
+    expect(tunnel.options.tunnel.username).to.equal("FAKE_USERNAME");
+    expect(tunnel.options.tunnel.password).to.equal("FAKE_PASSWORD");
+    expect(tunnel.options.tunnel.tunnelIdentifier).to.equal("FAKE_TUNNELID");
+  });
+
+  describe("initialize", () => {
+    it("successful", () => {
+      return tunnel
+        .initialize()
+        .catch(err => assert(false, "tunnel isn't initialized correctly." + err));
+    });
+
+    it("missing username", () => {
+      tunnel = new Tunnel({ tunnel: {} }, sauceConnectLauncherMock);
+
+      return tunnel
+        .initialize()
+        .then(() => assert(false, "tunnel username isn't processed correctly"))
+        .catch(err =>
+          expect(Promise.resolve(err))
+            .to.eventually
+            .equal("Sauce tunnel support is missing configuration: Sauce username."));
+    });
+
+    it("missing password", () => {
+      tunnel = new Tunnel({ tunnel: { username: "FAKE_USERNAME" } }, sauceConnectLauncherMock);
+
+      return tunnel
+        .initialize()
+        .then(() => assert(false, "tunnel password isn't processed correctly"))
+        .catch(err =>
+          expect(Promise.resolve(err))
+            .to.eventually
+            .equal("Sauce tunnel support is missing configuration: Sauce password."));
+    });
+
+    it("download error", () => {
+      sauceConnectLauncherMock.download = (opts, callback) => { callback("FAKE_ERROR") };
+
+      return tunnel
+        .initialize()
+        .then(() => assert(false, "tunnel download error isn't processed correctly"))
+        .catch(err =>
+          expect(Promise.resolve(err))
+            .to.eventually
+            .equal("FAKE_ERROR"));
+    });
+  });
+
+  describe("open", function () {
+    this.timeout(60000);
+
+    it("straight succeed", () => {
+      sauceConnectLauncherMock = (opts, callback) => {
+        callback(null, "FAKE_TUNNEL_PROCESS");
+      };
+
+      tunnel = new Tunnel(options, sauceConnectLauncherMock);
+
+      return tunnel
+        .open()
+        .then(() => expect(Promise.resolve(tunnel.tunnelInfo.process))
+          .to.eventually.equal("FAKE_TUNNEL_PROCESS"))
+        .catch(err => assert(false, "tunnel isn't open correctly." + err));
+    });
+
+    it("cannot start sauce connect", () => {
+      sauceConnectLauncherMock = (opts, callback) => {
+        callback(new Error("Could not start Sauce Connect"));
+      };
+
+      tunnel = new Tunnel(options, sauceConnectLauncherMock);
+
+      return tunnel
+        .open()
+        .then(() => assert(false, "tunnel isn't launch correctly." + err))
+        .catch(err => expect(Promise.resolve(err))
+          .to.eventually.equal("Could not start Sauce Connect"));
+    });
+
+    it("retry 10 times", () => {
+      sauceConnectLauncherMock = (opts, callback) => {
+        callback(new Error("FAIL_ON_PURPOSE"));
+      };
+
+      tunnel = new Tunnel(options, sauceConnectLauncherMock);
+
+      return tunnel
+        .open()
+        .then(() => assert(false, "tunnel isn't launch correctly." + err))
+        .catch(err => expect(Promise.resolve(err.message))
+          .to.eventually.equal("Failed to create a secure sauce tunnel after 10 attempts."));
+    });
+  });
+
+  describe("close", () => {
+    it("tunnel is already closed", () => {
+      return tunnel
+        .close()
+        .catch(err => assert(false, "tunnel isn't close correctly." + err));
+    });
+
+    it("tunnel isn't closed", () => {
+      tunnel.tunnelInfo = {
+        process: {
+          close(callback) { callback() }
+        }
+      };
+
+      return tunnel
+        .close()
+        .catch(err => assert(false, "tunnel isn't close correctly." + err));
+    });
+  });
+});

--- a/test/src/tunnel.test.js
+++ b/test/src/tunnel.test.js
@@ -14,7 +14,7 @@ describe("Tunnel", () => {
   let options = {
     tunnel: {
       username: "FAKE_USERNAME",
-      password: "FAKE_PASSWORD",
+      accessKey: "FAKE_PASSWORD",
       tunnelIdentifier: "FAKE_TUNNELID"
     }
   };
@@ -31,7 +31,7 @@ describe("Tunnel", () => {
 
   it("constructor", () => {
     expect(tunnel.options.tunnel.username).to.equal("FAKE_USERNAME");
-    expect(tunnel.options.tunnel.password).to.equal("FAKE_PASSWORD");
+    expect(tunnel.options.tunnel.accessKey).to.equal("FAKE_PASSWORD");
     expect(tunnel.options.tunnel.tunnelIdentifier).to.equal("FAKE_TUNNELID");
   });
 


### PR DESCRIPTION
This PR allows
1. launch up sauce tunnel for each test run and close it eventually after the run
2. use existing sauce tunnel for every test
3. validate tunnel config 