### PR TITLE
add verify on api body even no error

### DIFF
--- a/src/muffin.js
+++ b/src/muffin.js
@@ -41,9 +41,13 @@ export default {
           if (err) {
             reject(err);
           }
-
-          self._buildDeviceCache(JSON.parse(body));
-          resolve(deviceCache);
+          logger.debug(`Response: ${JSON.stringify(response)}`);
+          try {
+            self._buildDeviceCache(JSON.parse(body));
+            resolve(deviceCache);
+          } catch (e) {
+            reject(new Error(`StatusCode: ${response.statusCode}, error: ${e}`));
+          }
         });
       }
     });


### PR DESCRIPTION
add verify on API body even no error, the body may empty and `JSON.parse()` will throw exception